### PR TITLE
Ignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+Gemfile.lock
 .bundle
 *.swp
-


### PR DESCRIPTION
Allow users to use a range of versions for dependencies.
