### PR TITLE
Fix NoMethodError when jshint.js array has nil elm

### DIFF
--- a/lib/jshint/lint.rb
+++ b/lib/jshint/lint.rb
@@ -82,15 +82,22 @@ module JSHint
       errors
     end
 
+    # `run_lint` executes `jshint.js`, via `ExecJS`, on the given
+    # `source` (a string of JS source) and returns an array of
+    # errors.  Sometimes the array from `jshint.js` will contain
+    # `nil` elements.  For example, when there are "too many errors",
+    # `jshint.js` will return an array whose last element is `nil`.
+    # The array returned by `run_lint` omits any such `nil` elements.
     def run_lint(source)
       code = %(
         JSHINT(#{source.inspect}, #{MultiJson.dump(@config)});
         return JSHINT.errors;
       )
 
-      context.exec(code)
+      context.exec(code).compact
     end
 
+    # `context` returns an `ExecJS::ExternalRuntime::Context`
     def context
       @context ||= ExecJS.compile(File.read(JSHINT_FILE))
     end

--- a/spec/lint_spec.rb
+++ b/spec/lint_spec.rb
@@ -121,4 +121,20 @@ describe JSHint::Lint do
     end
   end
 
+  describe '#run_lint' do
+    context 'when the array returned by ExecJS contains a nil' do
+      it 'returns array in same order, but without the nil' do
+        err1 = double
+        err2 = double
+        execjs_context = double("ExecJS::ExternalRuntime::Context")
+        expect(execjs_context).to \
+          receive(:exec).and_return([err1, err2, nil])
+        lint = described_class.new
+        expect(lint).to receive(:context).and_return(execjs_context)
+        result = lint.send(:run_lint, double("JS Source"))
+        expect(result).to eq([err1, err2])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Sometimes the array from `jshint.js` will contain `nil` elements.
For example, when there are "too many errors", `jshint.js` will
return an array whose last element is `nil`. The array returned by
`run_lint` omits any such `nil` elements.
